### PR TITLE
set max_stream_window_size=100M

### DIFF
--- a/src/yamux-plugin-local.rs
+++ b/src/yamux-plugin-local.rs
@@ -57,6 +57,12 @@ async fn get_yamux_stream(
     const YAMUX_CONNECT_RETRY_COUNT: usize = 3;
 
     let mut connect_tried_count = 0;
+
+    let custom_config = Config {
+        max_stream_window_size: (100 * 1024 * 1024),
+        ..Config::default()
+    };
+
     let yamux_stream = loop {
         connect_tried_count += 1;
 
@@ -107,7 +113,7 @@ async fn get_yamux_stream(
             }
         };
 
-        let mut yamux_session = Session::new_client(remote_stream, Config::default());
+        let mut yamux_session = Session::new_client(remote_stream, custom_config);
         let yamux_control = yamux_session.control();
 
         tokio::spawn(async move {

--- a/src/yamux-plugin-server.rs
+++ b/src/yamux-plugin-server.rs
@@ -252,6 +252,11 @@ async fn main() -> io::Result<()> {
     let plugin_opts = Arc::new(plugin_opts);
     let context = Arc::new(context);
 
+    let custom_config = Config {
+        max_stream_window_size: (100 * 1024 * 1024),
+        ..Config::default()
+    };
+
     let tcp_fut = {
         let local_host = local_host.clone();
         let plugin_opts = plugin_opts.clone();
@@ -273,7 +278,7 @@ async fn main() -> io::Result<()> {
                 let local_host = local_host.clone();
                 let plugin_opts = plugin_opts.clone();
                 let context = context.clone();
-                let yamux_session = Session::new_server(stream, Config::default());
+                let yamux_session = Session::new_server(stream, custom_config);
                 tokio::spawn(handle_tcp_session(
                     context,
                     local_host,
@@ -302,7 +307,7 @@ async fn main() -> io::Result<()> {
             let local_host = local_host.clone();
             let plugin_opts = plugin_opts.clone();
             let context = context.clone();
-            let yamux_session = Session::new_server(stream, Config::default());
+            let yamux_session = Session::new_server(stream, custom_config);
             tokio::spawn(handle_tcp_session(
                 context,
                 local_host,


### PR DESCRIPTION
Optimize performance for high latency network environment. (#1)
According to
```
Bandwidth=((1000/t) * (MaxStreamWindowSize/2) * 8)/(1024*1024) Mbps
```
When latency t is 400ms and MaxStreamWindowSize is 100M,  the bandwidth is 1000Mbps in theory.